### PR TITLE
Rejected promises now returns the full res

### DIFF
--- a/src/superagent-promise-plugin.js
+++ b/src/superagent-promise-plugin.js
@@ -3,8 +3,7 @@ function endPromise(req) {
 
   return new _Promise(function (resolve, reject) {
     req.end(function (err, res) {
-      err = err || res.error;
-      if (err) reject(err);
+      if (err || res.error) reject(res);
       else resolve(res);
     });
   });

--- a/src/superagent-promise-plugin.js
+++ b/src/superagent-promise-plugin.js
@@ -3,8 +3,12 @@ function endPromise(req) {
 
   return new _Promise(function (resolve, reject) {
     req.end(function (err, res) {
-      if (err || res.error) reject(res);
-      else resolve(res);
+      err = err || res.error;
+      if (err) {
+        err.response = res;
+        reject(err);
+      } else 
+        resolve(res);
     });
   });
 }

--- a/test/superagent-promise-plugin.js
+++ b/test/superagent-promise-plugin.js
@@ -41,6 +41,7 @@ describe('superagentPromisePlugin', function () {
 
     function fail(err) {
       should(err.status).equal(404);
+      should(err.response).be.type('object');
     }
 
     Promise.all([


### PR DESCRIPTION
Returning the error text alone isn't helpful ; accessing the response body is sometimes necessary to obtain complementary data on the error.

What do you think ?
